### PR TITLE
Path of War OGL check

### DIFF
--- a/pathfinder/dreamscarred_press/path_of_war/OGL.txt
+++ b/pathfinder/dreamscarred_press/path_of_war/OGL.txt
@@ -33,4 +33,24 @@ The following text is the property of Wizards of the Coast, Inc. and is Copyrigh
 15 COPYRIGHT NOTICE
 Open Game License v 1.0a Copyright 2000, Wizards of the Coast, Inc.
 System Reference Document Copyright 2000-2003, Wizards of the Coast, Inc.; Authors Jonathan Tweet, Monte Cook, Skip Williams, Rich Baker, Andy Collins, David Noonan, Rich Redman, Bruce R. Cordell, John D. Rateliff, Thomas Reid, James Wyatt, based on original material by E. Gary Gygax and Dave Arneson.
-PCGen dataset conversion for the System Reference Document Copyright 2001-2004, PCgen Data team (Including, but not limited to Andrew McDougall (Tir Gwaith), Doug McMill, Paul W. King, Chris Chandler (Barak), Michael Gray (Taluonr Iscandar), Kenneth Walters (GldDragon35), Mike Sledge (zodar6), Patryk Adamski (Ruemere), Larry Davis (Sir George Anonymous), James Dempsey, Bryan (Merton Monk) McRoberts, Thomas Jannes (chipoulou), Samuel Hendricks (NotMousse), Sigurdur H. Olafsson, Jayme Cox, Jeremy "Illrigger" Turnley, Emily Smirle, Martin Fagerstr�m, Chris McLaughlin, Raymond Yao, Eddy Anthony (MoSaT), Thomas Clegg (Arknight), Andargor, Devon Jones)
+Pathfinder RPG Core Rulebook. Copyright 2009, Paizo Publishing, LLC; Author: Jason Bulmahn, based on material by Jonathan Tweet, Monte Cook, and Skip Williams.
+Pathfinder RPG Bestiary, Copyright 2009, Paizo Publishing, LLC; Author: Jason Bulmahn, based on material by Jonathan Tweet, Monte Cook, and Skip Williams.
+Advanced Player’s Guide, Copyright 2010, Paizo Publishing, LLC; Author: Jason Bulmahn
+Pathfinder RPG GameMastery Guide, Copyright 2010, Paizo Publishing, LLC; Author: Cam Banks, Wolfgang Buar, Jason Bulmahn, Jim Butler, Eric Cagle, Graeme Davis, Adam Daigle, Joshua J. Frost, James Jacobs, Kenneth Hite, Steven Kenson, Robin Laws, Tito Leati, Rob McCreary, Hal Maclean, Colin McComb, Jason Nelson, David Noonan, Richard Pett, Rich Redman, Sean K reynolds, F. Wesley Schneider, Amber Scorr, Doug Seacat, Mike Selinker, Lisa Stevens, James L. Sutter, Russ Taylor, Penny Williams, Skip Williams, Teeuwynn Woodruff.
+Pathfinder Roleplaying Game Ultimate Magic, Copyright 2011, Paizo Publishing, LLC; Authors: Jason Bulmahn, Tim Hitchcock, Colin McComb, Rob McCreary, Jason Nelson, Stephen Radney-MacFarland, Sean K Reynolds, Owen K.C. Stephens, and Russ Taylor.
+Pathfinder Roleplaying Game Ultimate Combat, Copyright 2011, Paizo Publishing, LLC; Authors: Dennis Baker, Jesse Benner, Benjamin Bruck, Jason Bulmahn, Brian J. Cortijo, Jim Groves, Tim Hitchcock, Richard A. Hunt, Colin McComb, Jason Nelson, Tom Phillips, Patrick Renie, Sean K Reynolds, and Russ Taylor.
+The Book of Experimental Might, Copyright 2008, Monte J. Cook. All rights reserved.
+Tome of Horrors, Copyright 2002, Necromancer Games, Inc.; Authors: Scott Greene, with Clark Peterson, Erica Balsley, Kevin Baase, Casey Christofferson, Lance Hawvermale, Travis Hawvermale, Patrick Lawinger, and Bill Webb; Based on original content from TSR.
+Unearthed Arcana, Copyright 2004, Wizards of the Coast, Inc.; Authors Andy Collins, Jesse Decker, David Noonan, Rich Redman
+The Iconic Bestiary: Classics of Fantasy, Copyright 2005, Lions Den Press; Author Ari Marmell
+Hyperconscious: Explorations in Psionics, Copyright 2004, Bruce R Cordell. All rights reserved.
+If Thoughts Could Kill, Copyright 2001–2004, Bruce R. Cordell. All rights reserved.
+Mindscapes, Copyright 2003–2004, Bruce R. Cordell. All rights reserved.
+Unearthed Arcana, Copyright 2004, Wizards of the Coast.
+Mutants & Masterminds Copyright 2002, Green Ronin Publishing.
+Swords of Our Fathers, Copyright 2003, The Game Mechanics.
+Modern System Reference Document, Copyright 2002, Wizards of the Coast, Inc.; Authors Bill Slavicsek, Jeff Grubb, Rich Redman, Charles Ryan, based on material by Jonathan Tweet, Monte Cook, Skip Williams, Richard Baker,Peter Adkison, Bruce R. Cordell, John Tynes, Andy Collins, and JD Wiker
+Psionics Unleashed. Copyright 2010, Dreamscarred Press.
+Path of War, Copyright 2014, Dreamscarred Press.
+PCGen dataset conversion for "Path of War" Copyright 2015, PCGen Data team (Including, but not limited to Douglas Limmer).
+


### PR DESCRIPTION
Cleared by OGL, the ogl.txt needed the copyright text from the pcc file